### PR TITLE
Just realized `data` can also be an atomic vector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+sudo: required
 
 before_install:
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - ./travis-tool.sh bootstrap
 
 install:
-  - ./travis-tool.sh install_github plyr
   - ./travis-tool.sh install_deps
 
 script: ./travis-tool.sh run_tests

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,9 @@ URL: http://github.com/hrbrmstr/metricsgraphics
 BugReports: https://github.com/hrbrmstr/metricsgraphics/issues
 License: MIT + file LICENSE
 Suggests:
-    testthat
+    testthat,
+    RColorBrewer,
+    ggplot2
 Depends:
     R (>= 3.0.0),
     htmlwidgets,

--- a/R/metricsgraphics.R
+++ b/R/metricsgraphics.R
@@ -72,7 +72,12 @@ mjs_plot <- function(data, x, y,
     y <- as.character(substitute(y))
   }
 
-  if (inherits(data[, x], c('Date', 'POSIXct', 'POSIXlt'))) {
+  is_datetime <- function(x) {
+    inherits(x, c('Date', 'POSIXct', 'POSIXlt'))
+  }
+  if (is.null(dim(data))) {
+    if (is_datetime(data)) data <- as.numeric(data)
+  } else if (is_datetime(data[, x])) {
     data[, x] <- as.numeric(data[, x])
   }
 


### PR DESCRIPTION
It is embarrassing that I'm submitting the third PR to fix this issue, since I did not notice the `data` argument can also be a numeric vector for histograms:

```r
mjs_plot(rnorm(10000)) %>%
  mjs_histogram(bins=30, bar_margin=1)
```