### PR TITLE
Allow explicit variable names

### DIFF
--- a/R/metricsgraphics.R
+++ b/R/metricsgraphics.R
@@ -59,14 +59,20 @@ mjs_plot <- function(data, x, y,
 
   if (!missing(x)) {
     x <- substitute(x)
-    if (inherits(x, "name")) { x <- as.character(x) }
+    res <- try(eval(x, data, parent.frame()), silent = TRUE)
+    if (!inherits(res, "try-error") && inherits(res, "character"))
+      x <- res
+    else if (inherits(x, "name")) { x <- as.character(x) }
   } else {
     x <- as.character(substitute(x))
   }
-
+  
   if (!missing(y)) {
     y <- substitute(y)
-    if (inherits(y, "name")) { y <- as.character(y) }
+    res <- try(eval(y, data, parent.frame()), silent = TRUE)
+    if (!inherits(res, "try-error") && inherits(res, "character"))
+      y <- res
+    else if (inherits(y, "name")) { y <- as.character(y) }
   } else {
     y <- as.character(substitute(y))
   }

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -27,6 +27,13 @@ tmp %>%
   mjs_axis_x(xax_format = 'plain')
 
 
+x = "wt"
+y = "mpg"
+mtcars %>%
+  mjs_plot(x=x, y=y, width=600, height=500) %>%
+  mjs_point(color_accessor=carb, size_accessor=carb) %>%
+  mjs_labs(x="Weight of Car", y="Miles per Gallon")
+
 mtcars %>%
   mjs_plot(x=wt, y=mpg, width=600, height=500) %>%
   mjs_point(color_accessor=carb, size_accessor=carb) %>%


### PR DESCRIPTION
This should fix #18.  I included a new test, and the `shiny` example below works as expected.
```
library(shiny)
library(metricsgraphics)

ui = shinyUI(
  fluidPage(
    sidebarPanel(
      selectInput("x", "X", colnames(mtcars), "wt"),
      selectInput("y", "Y", colnames(mtcars), "mpg")
    ),
    mainPanel(
      metricsgraphicsOutput('mjs1')
    )
  )
)

server = function(input, output) {
  output$mjs1 <- renderMetricsgraphics({
    mtcars %>%
      mjs_plot(x=input$x, y=input$y, width=400, height=300) %>%
      mjs_point(color_accessor=carb, size_accessor=carb) %>%
      mjs_labs(x="Weight of Car", y="Miles per Gallon")
  })
}

shinyApp(ui = ui, server = server)
```