### PR TITLE
define metricsgrahics-legend class via replacement rather than appending a suffix

### DIFF
--- a/R/metricsgraphics.R
+++ b/R/metricsgraphics.R
@@ -214,5 +214,6 @@ renderMetricsgraphics <- function(expr, env = parent.frame(), quoted = FALSE) {
 
 metricsgraphics_html <- function(id, style, class, ...) {
   list(tags$div(id = id, class = class, style = style),
-       tags$div(id = sprintf("%s-legend", id), class = sprintf("%s-legend", class)))
+       tags$div(id = sprintf("%s-legend", id),
+                class = gsub("metricsgraphics", "metricsgraphics-legend", class)))
 }


### PR DESCRIPTION
An upcoming change to htmlwidgets adds and "html-widget" class to all widget html containers. Previously the metricsgrahpics-legend class was establish by appending "-legend" to the current class however this resulted in a class of:

```
metricsgraphics html-widget-legend
```

This change modifies the class via string replacement, yielding:

```
metricsgraphics-legent html-widget
```