### PR TITLE
include point_size param in the mjs_point function

### DIFF
--- a/R/point.r
+++ b/R/point.r
@@ -37,6 +37,7 @@ mjs_point <- function(mjs,
   }
 
   mjs$x$chart_type <- "point"
+  mjs$x$point_size <- point_size
   mjs$x$least_squares<- least_squares
   mjs$x$x_rug <- x_rug
   mjs$x$y_rug <- y_rug


### PR DESCRIPTION
Hi!
While using this great pkg I noticed that setting the `point_size` parameter did nothing to change the point sizes.
I checked the `issues` log and [one of them](https://github.com/hrbrmstr/metricsgraphics/issues/32) was still open about this very thing.

After looking at the code I noticed the simple change hadn't been made yet and was probably forgotten about. So went ahead and did it really quick.

The `point_size` parameter was simply left out of the function body of the `mjs_point()` function even though it was defined in the `@params` section and was listed in the parameters inside the function call. I merely added it into the body.

Now the parameter works as expected and you can probably close out the issue linked above.